### PR TITLE
Add option for customizing whether an object gets transformed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 the keys of any nested objects &ndash; according to some function. Circular
 references are supported.
 
-To transform the *values* of an object rather than its keys, use
+To transform the _values_ of an object rather than its keys, use
 [Deep Map][deep-map].
 
 ## Install
@@ -122,6 +122,9 @@ And the result will look like this:
             <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this"><code>this</code></a>
             within <code>mapFn()</code>
           </li>
+          <li>
+            <strong>shouldTransformFn</strong> &lt;<code>function</code>&gt; Function used to customize whether a value in the object should be deeply/recursively mapped. The function receives a key and a value and must output a boolean.
+          </li>
         </ul>
       </td>
     </tr>
@@ -145,7 +148,7 @@ interface Result {
   userName: string;
 }
 
-let result = deepMapKeys<Result>({user_name: 'Pumbaa'}, snakeToCamel);
+let result = deepMapKeys<Result>({ user_name: 'Pumbaa' }, snakeToCamel);
 
 let name = result.userName; // Everything is OK :)
 ```

--- a/src/deep-map-keys.ts
+++ b/src/deep-map-keys.ts
@@ -12,6 +12,7 @@ export interface MapFn {
 
 export interface Opts {
   thisArg?: any;
+  shouldTransformFn?: (key?: string, value?: any) => boolean;
 }
 
 export class DeepMapKeys {
@@ -50,13 +51,16 @@ export class DeepMapKeys {
       return this.cache.get(obj);
     }
 
-    let {mapFn, opts: {thisArg}} = this;
+    let {mapFn, opts: {thisArg, shouldTransformFn}} = this;
     let result: NonPrimitive = {};
     this.cache.set(obj, result);
 
     for (let key in obj) {
       if (obj.hasOwnProperty(key)) {
-        result[mapFn.call(thisArg, key, obj[key])] = this.map(obj[key]);
+        result[mapFn.call(thisArg, key, obj[key])] =
+          (!shouldTransformFn || shouldTransformFn(key, obj[key])) ?
+            this.map(obj[key]) :
+            obj[key];
       }
     }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -99,6 +99,17 @@ describe('deepMapKeys(object, mapFn, [options])', () => {
 
     });
 
+    describe('option: shouldTransformFn', () => {
+      it('prevents mapping through values for which @shouldTransformFn returns false', () => {
+        let shouldTransformFn = sinon.spy((key: string, value: any) => key !== 'noTransform');
+        let obj = {one: 1, noTransform: {two: 2}};
+
+        deepMapKeys(obj, caps, {shouldTransformFn}).should.deep.equal({ONE: 1, NOTRANSFORM: {two: 2}});
+        shouldTransformFn.should.have.been.calledWith('one', 1);
+        shouldTransformFn.should.have.been.calledWith('noTransform', {two: 2});
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
Implements feature for issue #9, provides possible fix for issue #7 

We were seeing an issue where this library was invalidating Date and
other built-in Javascript objects. This option will give users control
over the mapping behavior.