### PR TITLE
[bugfix] handle null prototype objects

### DIFF
--- a/src/deep-map-keys.ts
+++ b/src/deep-map-keys.ts
@@ -55,7 +55,7 @@ export class DeepMapKeys {
     this.cache.set(obj, result);
 
     for (let key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.hasOwnProperty.call(obj, key)) {
         result[mapFn.call(thisArg, key, obj[key])] = this.map(obj[key]);
       }
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -102,3 +102,12 @@ describe('deepMapKeys(object, mapFn, [options])', () => {
   });
 
 });
+
+it('handles null prototype objects', () => {
+  const caps = (key: string) => key.toUpperCase(); 
+
+  const nullProtoObj = Object.create(null);
+  nullProtoObj.foo = 'bar';
+
+  deepMapKeys(nullProtoObj, caps).should.deep.equal({ FOO: 'bar' });
+});


### PR DESCRIPTION
@mcmath thanks for this library!

Came across an issue we're hitting - if this library called over any objects created with `Object.create(null)`, then an error is thrown because of this line:

https://github.com/mcmath/deep-map-keys/blob/4a2204554b31d1a32b761468391fc770cdfa4a4d/src/deep-map-keys.ts#L58

I've added a regression test, which also demonstrates the issue:

### before

```
$ npm run test:unit

> deep-map-keys@2.0.1 test:unit
> istanbul cover -e .ts -x '*.test.ts' _mocha -- src --opts mocha.opts

  !․․․․․․․․․․․․․

  13 passing (39ms)
  1 failing

  1) handles null prototype objects:
     TypeError: obj.hasOwnProperty is not a function
      at DeepMapKeys.mapObject (src/deep-map-keys.ts:1:6130)
      at DeepMapKeys.map (src/deep-map-keys.ts:1:5022)
      at deepMapKeys (src/index.ts:1:3000)
      at Context.<anonymous> (src/index.test.ts:112:3)
      at processImmediate (node:internal/timers:471:21)

```

### after

it passes!